### PR TITLE
Start breadbrumb widget from end

### DIFF
--- a/lib/flutter_breadcrumb_menu.dart
+++ b/lib/flutter_breadcrumb_menu.dart
@@ -79,8 +79,7 @@ class Breadcrumb<T> extends StatelessWidget {
             },
             separatorBuilder: (BuildContext ctx, int index) => separator,
           ),
-        ),
-        Divider(),
+        )
       ],
     );
 

--- a/lib/flutter_breadcrumb_menu.dart
+++ b/lib/flutter_breadcrumb_menu.dart
@@ -1,6 +1,7 @@
 library flutter_breadcrumb_menu;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
 class Bread<T> {
   final T route;
@@ -30,11 +31,14 @@ class Breadcrumb<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    final controller = ScrollController();
+
+    final widget = Column(
       children: <Widget>[
         Container(
           height: height,
           child: ListView.separated(
+            controller: controller,
             itemCount: breads.length,
             scrollDirection: Axis.horizontal,
             itemBuilder: (BuildContext ctx, int index) {
@@ -79,5 +83,10 @@ class Breadcrumb<T> extends StatelessWidget {
         Divider(),
       ],
     );
+
+    SchedulerBinding.instance.addPostFrameCallback(
+        (timeStamp) => controller.jumpTo(controller.position.maxScrollExtent));
+
+    return widget;
   }
 }


### PR DESCRIPTION
I think it's most useful for user to see end of breadcrumb. This allows the most common action, going up one or 2 levels, even if deeply nested.