### PR TITLE
Allow last active

### DIFF
--- a/lib/flutter_breadcrumb_menu.dart
+++ b/lib/flutter_breadcrumb_menu.dart
@@ -51,12 +51,12 @@ class Breadcrumb<T> extends StatelessWidget {
             scrollDirection: Axis.horizontal,
             itemBuilder: (BuildContext ctx, int index) {
               final bread = breads[index];
-              bool isLast = bread == breads.last;
-              Color _color = isLast ? Colors.grey : color;
+              bool isDisabled = bread == breads.last && !isLastActive;
+              Color _color = isDisabled ? Colors.grey : color;
 
               return InkWell(
                 onTap: () {
-                  if (isLast && !isLastActive) {
+                  if (isDisabled) {
                     return;
                   }
                   final route = bread.route;

--- a/lib/flutter_breadcrumb_menu.dart
+++ b/lib/flutter_breadcrumb_menu.dart
@@ -18,6 +18,13 @@ class Breadcrumb<T> extends StatelessWidget {
   final ValueChanged<T?>? onValueChanged;
   final List<Bread<T>> breads;
 
+  /// Set this to true if in your usage you want to override that, and allow the last
+  /// item to be clickable.
+  /// In general, the last crumb is assumed to be current view and is not clickable.
+  /// If you aren't showing the current item in the breadcrumb list, you probably
+  /// want all breadcrumbs to be clickable.
+  final bool isLastActive;
+
   const Breadcrumb({
     this.height = 40.0,
     this.color = Colors.blue,
@@ -26,8 +33,9 @@ class Breadcrumb<T> extends StatelessWidget {
       size: 12.0,
     ),
     this.onValueChanged,
+    bool isLastActive = false,
     required this.breads,
-  });
+  }) : isLastActive = isLastActive;
 
   @override
   Widget build(BuildContext context) {
@@ -48,7 +56,7 @@ class Breadcrumb<T> extends StatelessWidget {
 
               return InkWell(
                 onTap: () {
-                  if (isLast) {
+                  if (isLast && !isLastActive) {
                     return;
                   }
                   final route = bread.route;
@@ -58,11 +66,11 @@ class Breadcrumb<T> extends StatelessWidget {
                   } else {
                     if (route is String) {
                       Navigator.of(context).pushNamed(
-                        route!,
+                        route,
                         arguments: arguments,
                       );
                     } else if (route is PageRoute) {
-                      Navigator.of(context).push(route!);
+                      Navigator.of(context).push(route);
                     }
                   }
                 },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -66,14 +66,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -141,6 +141,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
I was updating some designs in my app, and realized I wanted current section title to be more prominent.
Which I did.
But then the last item in breadcrumb wasn't current route, it was parent, so I wanted it to be clickable.
So here I added a property to make last item clickable.

I also removed some extra not null assertions.